### PR TITLE
Modify completion return values

### DIFF
--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -170,7 +170,7 @@ class Source(Base):
         signature = re.sub('\s+', '', signature)
         menu_text = signature.strip("(method)").strip("(property)")
         documentation = menu_text
-        if entry["documentation"]:
+        if "documentation" in entry and entry["documentation"]:
             documentation += "\n" + entry["documentation"][0]["text"]
 
         kind = entry["kind"][0].title()

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -173,9 +173,10 @@ class Source(Base):
         if entry["documentation"]:
             documentation += "\n" + entry["documentation"][0]["text"]
 
+        kind = entry["kind"][0].title()
         return ({
             "word": name,
-            "kind": entry["kind"],
+            "kind": kind,
             "menu": menu_text,
             "info": documentation
         })

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -167,7 +167,7 @@ class Source(Base):
         signature = ''.join([p['text'] for p in display_parts])
 
         # needed to strip new lines and indentation from the signature
-        signature = re.sub('\s+', ' ', signature)
+        signature = re.sub('\s+', '', signature)
         menu_text = signature.strip("(method)").strip("(property)")
         documentation = menu_text
         if entry["documentation"]:

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -169,8 +169,13 @@ class Source(Base):
         # needed to strip new lines and indentation from the signature
         signature = re.sub('\s+', ' ', signature)
         menu_text = signature.strip("(method)").strip("(property)")
+        documentation = menu_text
+        if entry["documentation"]:
+            documentation += "\n" + entry["documentation"][0]["text"]
+
         return ({
             "word": name,
             "kind": entry["kind"],
-            "info": menu_text
+            "menu": menu_text,
+            "info": documentation
         })


### PR DESCRIPTION
Making the completions a bit more useful and similar to other plugins (deoplete-ternjs and vim-javacomplete2 for instance)

1. Display documentation in the preview window, method signatures in the candidate completion menu
2. Instead of displaying properties and methods in the menu, shorten to be single letters
3. Strip extraneous space from the method signature

I know the method signatures in the menu was removed in 5f0547dd62fe26003e0c6777313935eda7b87754 but I find them rather useful and get the impression that they are generally shown there while the preview window is used for documentation. Ternjs allows them to be toggled using `tern_show_signature_in_pum` and if desired I can implement an equivalent