### PR TITLE
Fix signature striping

### DIFF
--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -171,7 +171,7 @@ class Source(Base):
 
         # needed to strip new lines and indentation from the signature
         signature = re.sub('\s+', '', signature)
-        menu_text = signature.strip("(method)").strip("(property)")
+        menu_text = re.sub('^\(method\)|^\(property\)', '', signature)
         documentation = menu_text
         if "documentation" in entry and entry["documentation"]:
             documentation += "\n" + entry["documentation"][0]["text"]


### PR DESCRIPTION
Hi !

`signature.strip("(method)").strip("(property)")` actually strips **ALL** the letters contained in `method` and `property`. So `(property)MyClass.user: User` would be striped to `MyClass.user: Us`. I fixed it with a Regex substitution.

By the way I wondered in which cases you needed to remove all the spaces from the signature ?