### PR TITLE
Fix missing 'request_seq' key error

### DIFF
--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -76,10 +76,10 @@ class Source(Base):
                     raise RuntimeError("Missing 'Content-Length' header")
                 contentlength = int(headers["Content-Length"])
                 ret = json.loads(self._tsserver_handle.stdout.read(contentlength))
-                if ret['request_seq'] == seq:
-                    return ret
-                elif ret['request_seq'] > seq:
+                if 'request_seq' not in ret or ret['request_seq'] > seq:
                     return None
+                elif ret['request_seq'] == seq:
+                    return ret
 
     def _write_message(self, message):
         self._tsserver_handle.stdin.write(json.dumps(message))


### PR DESCRIPTION
When TS encounters a compilation error TSServer doesn't return the `request_seq` key. This fix prevent deoplete-typescript from crashing in these cases.