### PR TITLE
Readability improvements

### DIFF
--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -174,8 +174,8 @@ class Source(Base):
         signature = re.sub('\s+', '', signature)
         menu_text = re.sub('^(var|let|const|class|\(method\)|\(property\)|enum|namespace|function|import|interface|type)', '', signature)
         documentation = menu_text
-        if "documentation" in entry and entry["documentation"]:
-            documentation += "\n" + entry["documentation"][0]["text"]
+        if 'documentation' in entry and entry['documentation']:
+            documentation += '\n' + ''.join([d['text'] for d in entry['documentation']])
 
         kind = entry["kind"][0].title()
         return ({

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -171,8 +171,8 @@ class Source(Base):
         signature = ''.join([p['text'] for p in display_parts])
 
         # needed to strip new lines and indentation from the signature
-        signature = re.sub('\s+', '', signature)
-        menu_text = re.sub('^(var|let|const|class|\(method\)|\(property\)|enum|namespace|function|import|interface|type)', '', signature)
+        signature = re.sub('[\n\r]+|^\s+', '', signature)
+        menu_text = re.sub('^(var|let|const|class|\(method\)|\(property\)|enum|namespace|function|import|interface|type)\s+', '', signature)
         documentation = menu_text
         if 'documentation' in entry and entry['documentation']:
             documentation += '\n' + ''.join([d['text'] for d in entry['documentation']])

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -171,7 +171,7 @@ class Source(Base):
         signature = ''.join([p['text'] for p in display_parts])
 
         # needed to strip new lines and indentation from the signature
-        signature = re.sub('[\n\r]+|^\s+', '', signature)
+        signature = re.sub('\s+', ' ', signature)
         menu_text = re.sub('^(var|let|const|class|\(method\)|\(property\)|enum|namespace|function|import|interface|type)\s+', '', signature)
         documentation = menu_text
         if 'documentation' in entry and entry['documentation']:

--- a/rplugin/python3/deoplete/sources/typescript.py
+++ b/rplugin/python3/deoplete/sources/typescript.py
@@ -172,7 +172,7 @@ class Source(Base):
 
         # needed to strip new lines and indentation from the signature
         signature = re.sub('\s+', '', signature)
-        menu_text = re.sub('^\(method\)|^\(property\)', '', signature)
+        menu_text = re.sub('^(var|let|const|class|\(method\)|\(property\)|enum|namespace|function|import|interface|type)', '', signature)
         documentation = menu_text
         if "documentation" in entry and entry["documentation"]:
             documentation += "\n" + entry["documentation"][0]["text"]


### PR DESCRIPTION
First of all, I removed unnecessary keywords in signature (they're already represented with a capital letter), and then I added the full documentation in preview window (eg. JSDoc's `@return` definition). By the way I re-enabled spaces inside signatures, while still striping indentation and new lines.
I don't know if all these are what you want for this plugin but I found these modifications improved readability on my daily usage.