### PR TITLE
fix error if "getDoc" method returns None

### DIFF
--- a/rplugin/python3/ts.py
+++ b/rplugin/python3/ts.py
@@ -82,7 +82,7 @@ class TypescriptHost():
         line = self.vim.current.window.cursor[0]
         offset = self.vim.current.window.cursor[1] + 2
         info = self._client.getDoc(file, line, offset)
-        if not info['success']:
+        if (not info) or (not info['success']):
             self.vim.command(
                 'echohl WarningMsg | echo "TS: No doc at cursor" | echohl None')
         else:
@@ -100,7 +100,7 @@ class TypescriptHost():
         line = self.vim.current.window.cursor[0]
         offset = self.vim.current.window.cursor[1] + 2
         info = self._client.goToDefinition(file, line, offset)
-        if not info['success']:
+        if (not info) or (not info['success']):
             self.vim.command(
                 'echohl WarningMsg | echo "TS: No definition" | echohl None')
         else:
@@ -121,7 +121,7 @@ class TypescriptHost():
         offset = self.vim.current.window.cursor[1] + 2
 
         info = self._client.getDoc(file, line, offset)
-        if not info['success']:
+        if (not info) or (not info['success']):
             pass
         else:
             message = '{0}'.format(info['body']['displayString'])


### PR DESCRIPTION
Hi, thanks for nice plugin!

When I used this plugin,  followin error occured.

```
error caught in async handler '/Users/pocari/.cache/dein/repos/github.com/mhartington/deoplete-typescript/rplugin/python3/ts.py:command:TSType []'
Traceback (most recent call last):
  File "/Users/pocari/.cache/dein/repos/github.com/mhartington/deoplete-typescript/rplugin/python3/ts.py", line 124, in tstype
    if not info['success']:
TypeError: 'NoneType' object is not subscriptable
```

So, I taken a request log, response was following.

```
{'seq': 0, 'type': 'event', 'body': {'diagnostics': [], 'configFile': '/Users/pocari/dev/tmp/20161107/ionic-conference-app/tsconfig.json'}, 'event': 'configFileDiag'}
```


I checked `send_request` method (in `client.py`)

```
                # Each response should contain a "request_seq"
                if "request_seq" not in ret or ret["request_seq"] > seq:
                    return None
```

Finally I have worked arround adding `(not info)`  condition.
